### PR TITLE
Support older pipelines without build-image-index

### DIFF
--- a/pipeline-patcher
+++ b/pipeline-patcher
@@ -229,6 +229,13 @@ detect_oci_ta_pipeline() {
     detect_task_in_pipeline $pipeline_file "*-oci-ta"
 }
 
+# Does the pipeline include the build-image-index task?
+detect_build_image_index() {
+    local pipeline_file="$1"
+
+    detect_task_in_pipeline $pipeline_file "build-image-index"
+}
+
 # Create the yaml snippet for a particular pipeline task and insert it into a pipeline
 # definition right before a particular other task. Do a few sanity checks beforehand.
 insert_pipeline_task() {
@@ -283,8 +290,15 @@ insert_pipeline_task() {
     # Somewhere to stash the pipeline task yaml
     local task_yaml_tmp="/tmp/$new_task_name.yaml"
 
-    # Prepare the yaml snippet to insert
-    extract_pipeline_task "$new_task_name" > "$task_yaml_tmp"
+
+    if detect_build_image_index "$pipeline_file"; then
+        # Prepare the yaml snippet to insert (use it as is)
+        extract_pipeline_task "$new_task_name" > "$task_yaml_tmp"
+    else
+        # Do some surgery on the yaml to (hopefully) support older pipelines where there
+        # is no build-image-index task. We're assuming there is a build-container task.
+        extract_pipeline_task "$new_task_name" | sed 's/build-image-index/build-container/g' > "$task_yaml_tmp"
+    fi
 
     # Awk will look for this line so it knows where to insert the new task
     local before_line_match="- name: $before_task_pipeline_name"

--- a/spec/pipeline-patcher_spec.sh
+++ b/spec/pipeline-patcher_spec.sh
@@ -95,3 +95,45 @@ Adding task sast-unicode-check-oci-ta to pipeline $tmp_dir/.tekton/cli-v06-push.
     # Todo maybe: Make a baseline file and check that it matches exactly
   End
 End
+
+Describe 'add-tasks-with-build-container'
+  # Prepare a git repo for testing
+  # Todo: Move this into a helper..?
+  tmp_dir=$(mktemp -d)
+  trap "rm -rf $tmp_dir" EXIT
+  (
+    example_from_github="https://raw.githubusercontent.com/konflux-ci/mintmaker-renovate-image/9ca00ff4e7d87cfb768a2b6eff0185e9b8c8745f"
+    cd $tmp_dir && git init . && mkdir .tekton && cd .tekton
+    for y in push pull-request; do curl -sLO $example_from_github/.tekton/mintmaker-renovate-image-$y.yaml; done
+    git add * && git commit -m "Testing"
+  ) > /dev/null
+
+  show_diff() {
+    cd $tmp_dir && git diff
+  }
+
+  It 'produces expected output'
+    # Beware this pulls data from both github and quay
+    When run ./pipeline-patcher add-tasks $tmp_dir sast-shell-check,sast-unicode-check
+    The status should be success
+    The output should equal "Adding task sast-shell-check to pipeline $tmp_dir/.tekton/mintmaker-renovate-image-pull-request.yaml
+Adding task sast-unicode-check to pipeline $tmp_dir/.tekton/mintmaker-renovate-image-pull-request.yaml
+Adding task sast-shell-check to pipeline $tmp_dir/.tekton/mintmaker-renovate-image-push.yaml
+Adding task sast-unicode-check to pipeline $tmp_dir/.tekton/mintmaker-renovate-image-push.yaml
+ .tekton/mintmaker-renovate-image-pull-request.yaml | 48 ++++++++++++++++++++++
+ .tekton/mintmaker-renovate-image-push.yaml         | 48 ++++++++++++++++++++++
+ 2 files changed, 96 insertions(+)"
+    The value "$(show_diff)" should include "+    - name: sast-shell-check"
+    The value "$(show_diff)" should include "+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check:0.1@sha256"
+    The value "$(show_diff)" should include "+    - name: sast-unicode-check"
+    The value "$(show_diff)" should include "+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check:0.1@sha256"
+
+    # Check that build-image-index was replaced with build-container
+    The value "$(show_diff)" should not include 'build-image-index'
+    The value "$(show_diff)" should include '+          value: $(tasks.build-container.results.IMAGE_URL)'
+    The value "$(show_diff)" should include '+          value: $(tasks.build-container.results.IMAGE_DIGEST)'
+    The value "$(show_diff)" should include '+        - build-container'
+
+    # Todo maybe: Make a baseline file and check that it matches exactly
+  End
+End


### PR DESCRIPTION
If the build-image-index task doesn't exist, instead use the build-container task.

Ref: https://issues.redhat.com/browse/EC-1202