### PR TITLE
chore: macos portability over piping

### DIFF
--- a/pipeline-patcher
+++ b/pipeline-patcher
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 KONFLUX_CATALOG=quay.io/konflux-ci/tekton-catalog


### PR DESCRIPTION
chore: fix broken pipe error on macOS by using modern bash
The test suite was failing on macOS with "echo: write error: Broken pipe"
when piping list_known_tasks output to grep -q. This occurred because:

- macOS ships with ancient bash 3.2.57 (from 2007) at /bin/bash
- Bash 3.2 reports SIGPIPE errors to stderr when grep -q exits early
- Bash 4+ silently handles this as expected behavior

Solution: Changed shebang from #!/bin/bash to #!/usr/bin/env bash to use
the modern bash from Homebrew (5.3+) which is already in PATH on macOS
development systems. This is more portable and allows users to choose
their bash version.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>